### PR TITLE
Fix intended method call `resource.displayname` -> `.displayname()`

### DIFF
--- a/arches_extensions/management/commands/make_file_list.py
+++ b/arches_extensions/management/commands/make_file_list.py
@@ -91,7 +91,7 @@ specific resources.
 
         ## stub out entry for this resource
         output = {
-            "name": resource.displayname,
+            "name": resource.displayname(),
             "resourceid": str(resource.pk),
             "file_data": {}
         }


### PR DESCRIPTION
This fixes the CSV output of the admin command `make_file_list` to show the resource name. Main branch currently prints python output about `displayname` being a method.